### PR TITLE
#29 Only admins can create user account

### DIFF
--- a/src/Config/index.js
+++ b/src/Config/index.js
@@ -18,5 +18,6 @@ switch (process.env.NODE_ENV) {
 }
 config.JWT_SECRET = process.env.JWT_SECRET;
 config.CLOUDINARY = process.env.CLOUDINARY_URL;
+config.ADMIN = process.env.ADMIN;
 
 export default config;

--- a/src/Controllers/employee.js
+++ b/src/Controllers/employee.js
@@ -7,7 +7,7 @@ export default class EmployeeController {
     try {
       const employee = await Employee.create(req.body);
       const payload = {
-        status: employee.jobrole.toLowerCase(),
+        status: employee.jobrole,
         email: employee.email,
         userId: employee.id,
       };

--- a/src/DB/createTables.js
+++ b/src/DB/createTables.js
@@ -56,10 +56,10 @@ const createTableArticles = `CREATE TABLE articles(
 const dropTableEmployees = 'DROP TABLE IF EXISTS employees CASCADE';
 const createTableEmployees = `CREATE TABLE employees(
   id bigserial NOT NULL,
-  firstName character varying(50) NOT NULL,
+  firstName character varying(50),
   lastName character varying(50),
   gender character varying (15),
-  jobRole character varying (60),
+  jobRole character varying (60) NOT NULL,
   email character varying (100) NOT NULL,
   password character varying NOT NULL,
   department character varying (100),

--- a/src/Middlewares/jwtHelper.js
+++ b/src/Middlewares/jwtHelper.js
@@ -36,9 +36,11 @@ export default class JWT {
   }
 
   static authorizeAdmin(req, res, next) {
-    const { status } = req.user;
-    if (status !== 'admin') {
-      next(new ErrorHandler('Unauthorized access', 403));
+    const { jobRole } = req.body;
+    if (jobRole.toLowerCase() !== config.ADMIN) {
+      next(
+        new ErrorHandler('Unauthorized access: Only admins are permitted', 403),
+      );
     } else {
       next();
     }

--- a/src/Routes/employee.js
+++ b/src/Routes/employee.js
@@ -1,8 +1,9 @@
 import { Router } from 'express';
 import Employee from '../Controllers/employee';
+import { Jwt } from '../Middlewares';
 
 const router = Router();
-router.post('/create-user', Employee.create);
+router.post('/create-user', Jwt.authorizeAdmin, Employee.create);
 router.post('/signin', Employee.signIn);
 
 export default router;

--- a/src/Tests/Mockups/employee.js
+++ b/src/Tests/Mockups/employee.js
@@ -5,7 +5,7 @@ class Employee {
       lastName: 'Chinazom',
       email: 'ezeemmanuel2010@gmail.com',
       password: 'adminPassword',
-      jobRole: 'Admin',
+      jobRole: 'admin@20_@',
       gender: 'Male',
       department: 'Management',
       address: 'Lambe street, Lagos',
@@ -19,6 +19,13 @@ class Employee {
     this.invalidEmployee = {
       email: 'invaliduser@gmail.com',
       password: 'invalidpassword',
+    };
+
+    this.notAdmin = {
+      firstName: 'Chinazom',
+      email: 'notAdmin@gmail.com',
+      password: 'notadmin',
+      jobRole: 'Engineer',
     };
   }
 }

--- a/src/Tests/employee.test.js
+++ b/src/Tests/employee.test.js
@@ -1,3 +1,6 @@
+/* eslint-disable indent */
+/* eslint-disable comma-dangle */
+/* eslint-disable no-trailing-spaces */
 import { describe, it } from 'mocha';
 import chai, { expect, should } from 'chai';
 import chaiHttp from 'chai-http';
@@ -7,12 +10,14 @@ import Employee from './Mockups/employee';
 
 chai.use(chaiHttp);
 should();
-const { employee, validEmployee, invalidEmployee } = new Employee();
+const {
+ employee, validEmployee, invalidEmployee, notAdmin 
+} = new Employee();
 const route = '/api/v1/auth';
 
 describe('EMPLOYEE AUTHENTICATION TEST', () => {
   describe('Create User Account', () => {
-    it('Only Admin should create user account', (done) => {
+    it('Create an admin account', (done) => {
       chai
         .request(server)
         .post(`${route}/create-user`)
@@ -32,10 +37,25 @@ describe('EMPLOYEE AUTHENTICATION TEST', () => {
         })
         .catch(err => done(err));
     });
+
+    it('throw error if the employee is not an admin', (done) => {
+      chai
+        .request(server)
+        .post(`${route}/create-user`)
+        .send(notAdmin)
+        .then((res) => {
+          expect(res.body).to.have.property('error');
+          expect(res.body.error).to.eql(
+            'Unauthorized access: Only admins are permitted',
+          );
+          done();
+        })
+        .catch(err => done(err));
+    });
   });
 
   describe('Sign in feature', () => {
-    it('Admin/Employee can sign in', (done) => {
+    it('Admin can sign in', (done) => {
       chai
         .request(server)
         .post(`${route}/signin`)


### PR DESCRIPTION
#### What does this PR do?
Only admin can create an employee account
#### How should this be manually tested?
Clone the repo and install all the dependencies using npm install
Create an admin account using the admin job role, it should create account
Now, try using a non-admin job role to create an account, you will not be able to do it
